### PR TITLE
Refactor graph.js

### DIFF
--- a/frontend/src/main/main.js
+++ b/frontend/src/main/main.js
@@ -118,7 +118,7 @@ class MainView extends React.Component {
         super(props);
         this.state = {
             config: {
-                width: 1000,
+                width: 500,
                 height: 800,
                 color: 'blue',
             },  // initial configuration for the viz


### PR DESCRIPTION
This PR heavily refactors graph.js for readability and to simplify some functionality. Lots of TODOs, but the code should be more straightforward to read now.

It's feature parity with the old version, except that I deliberately removed the second force simulation (the text labels bouncing around the circles) for simplicity. Text labels and circles are now children of the same SVG groups.