### PR TITLE
Responsive graph

### DIFF
--- a/frontend/src/main/graph.js
+++ b/frontend/src/main/graph.js
@@ -48,6 +48,17 @@ export function create_graph(el, data, config, handle_viz_events) {
             .attr("height", graph_height);
 
 
+    d3.select(window).on("resize", resize);
+
+    function resize() {
+
+        const width = window.innerWidth;
+        const height = window.innerHeight;
+        svg.attr("width", width).attr("height", height);
+        console.log(width,height);
+        force_simulation.force("center", d3.forceCenter(width / 2,height / 2));
+    }
+
     // Create links
     const links = svg
         .append("g")
@@ -212,10 +223,12 @@ export function update_graph_color(el, data, config) {
         .style('fill', config.color)
 }
 
-export function update_graph_size(el, data, config) {
-    // Re-compute the scales, and render the data points
-    // TODO: the main SVG should really have an ID
-    d3.select(el).select('svg')
-        .attr("width", config.width)
-        .attr("height", config.height);
-}
+
+
+// export function update_graph_size(el, data, config) {
+//     // Re-compute the scales, and render the data points
+//     // TODO: the main SVG should really have an ID
+//     d3.select(el).select('svg')
+//         .attr("width", config.width)
+//         .attr("height", config.height);
+// }

--- a/frontend/src/main/graph.js
+++ b/frontend/src/main/graph.js
@@ -224,13 +224,3 @@ export function update_graph_color(el, data, config) {
         .duration(1000)
         .style('fill', config.color)
 }
-
-
-
-// export function update_graph_size(el, data, config) {
-//     // Re-compute the scales, and render the data points
-//     // TODO: the main SVG should really have an ID
-//     d3.select(el).select('svg')
-//         .attr("width", config.width)
-//         .attr("height", config.height);
-// }

--- a/frontend/src/main/graph.js
+++ b/frontend/src/main/graph.js
@@ -149,8 +149,19 @@ export function create_graph(el, data, config, handle_viz_events) {
     function dragged(d) {
         d.fx = d3.event.x;
         d.fy = d3.event.y;
+        fix_nodes(d);
     }
 
+    // Preventing other nodes from moving while dragging one node
+    function fix_nodes(this_node) {
+        nodes.each(
+            function(node){
+            if (this_node != node){
+                node.fx = node.x;
+                node.fy = node.y;
+             }
+         });
+     }
 
     function drag_ended(d) {
         if (!d3.event.active) {force_simulation.alphaTarget(0);}

--- a/frontend/src/main/graph.js
+++ b/frontend/src/main/graph.js
@@ -33,7 +33,7 @@ export function create_graph(el, data, config, handle_viz_events) {
     const graph_y_center = graph_height / 2;
 
     const force_simulation = d3.forceSimulation(data.nodes)
-        .force("link", force_link)
+    force_simulation.force("link", force_link)
         .force("charge", d3.forceManyBody().strength(-5000))
         .force("center", d3.forceCenter(graph_x_center, graph_y_center))
         .force("x", d3.forceX(graph_x_center).strength(1))
@@ -48,16 +48,7 @@ export function create_graph(el, data, config, handle_viz_events) {
             .attr("height", graph_height);
 
 
-    d3.select(window).on("resize", resize);
 
-    function resize() {
-
-        const width = window.innerWidth;
-        const height = window.innerHeight;
-        svg.attr("width", width).attr("height", height);
-        console.log(width,height);
-        force_simulation.force("center", d3.forceCenter(width / 2,height / 2));
-    }
 
     // Create links
     const links = svg
@@ -202,6 +193,17 @@ export function create_graph(el, data, config, handle_viz_events) {
     function unfocus_node() {
         nodes.style("opacity", 1);
         links.style("opacity", 1);
+    }
+
+    d3.select(window).on("resize", resize);
+
+    function resize() {
+        const width = window.innerWidth;
+        const height = window.innerHeight;
+        svg.attr("width", width).attr("height", height);
+        console.log(width,height);
+        force_simulation.force("center", d3.forceCenter(width / 2,height / 2)).restart();
+        render_simulation(); // not sure if this makes a difference
     }
 }
 

--- a/frontend/src/main/graph.js
+++ b/frontend/src/main/graph.js
@@ -149,19 +149,8 @@ export function create_graph(el, data, config, handle_viz_events) {
     function dragged(d) {
         d.fx = d3.event.x;
         d.fy = d3.event.y;
-        fix_nodes(d);
     }
 
-    // Preventing other nodes from moving while dragging one node
-    function fix_nodes(this_node) {
-        nodes.each(
-            function(node){
-            if (this_node != node){
-                node.fx = node.x;
-                node.fy = node.y;
-             }
-         });
-     }
 
     function drag_ended(d) {
         if (!d3.event.active) {force_simulation.alphaTarget(0);}

--- a/frontend/src/main/main.js
+++ b/frontend/src/main/main.js
@@ -5,7 +5,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { getCookie } from '../common'
-// import { create_graph, update_graph_color, update_graph_size } from './graph.js'
 import { create_graph, update_graph_color} from './graph.js'
 import './main.css';
 
@@ -68,9 +67,6 @@ class Viz extends React.Component {
         if (this.props.config.viz_update_func === 'update_graph_color') {
             update_func = update_graph_color;
         }
-        // else if (this.props.config.viz_update_func === 'update_graph_size'){
-        //     update_func = update_graph_size;
-        // }
         update_func(
             this._graphRoot.current,
             this.props.data,
@@ -188,16 +184,6 @@ class MainView extends React.Component {
             }).catch(() => {
                 console.log("error");
             });
-        // window.addEventListener("resize", () => {
-        //     const config = {...this.state.config};
-        //     config.width = window.innerWidth;
-        //     config.height = window.innerHeight;
-        //
-        //     config.viz_update_func = 'update_graph_size';
-        //     this.setState({
-        //         config: config,
-        //     })
-        // });
     }
 
     /**

--- a/frontend/src/main/main.js
+++ b/frontend/src/main/main.js
@@ -5,7 +5,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { getCookie } from '../common'
-import { create_graph, update_graph_color, update_graph_size } from './graph.js'
+// import { create_graph, update_graph_color, update_graph_size } from './graph.js'
+import { create_graph, update_graph_color} from './graph.js'
 import './main.css';
 
 
@@ -67,9 +68,9 @@ class Viz extends React.Component {
         if (this.props.config.viz_update_func === 'update_graph_color') {
             update_func = update_graph_color;
         }
-        else if (this.props.config.viz_update_func === 'update_graph_size'){
-            update_func = update_graph_size;
-        }
+        // else if (this.props.config.viz_update_func === 'update_graph_size'){
+        //     update_func = update_graph_size;
+        // }
         update_func(
             this._graphRoot.current,
             this.props.data,
@@ -187,16 +188,16 @@ class MainView extends React.Component {
             }).catch(() => {
                 console.log("error");
             });
-        window.addEventListener("resize", () => {
-            const config = {...this.state.config};
-            config.width = window.innerWidth;
-            config.height = window.innerHeight;
-
-            config.viz_update_func = 'update_graph_size';
-            this.setState({
-                config: config,
-            })
-        });
+        // window.addEventListener("resize", () => {
+        //     const config = {...this.state.config};
+        //     config.width = window.innerWidth;
+        //     config.height = window.innerHeight;
+        //
+        //     config.viz_update_func = 'update_graph_size';
+        //     this.setState({
+        //         config: config,
+        //     })
+        // });
     }
 
     /**


### PR DESCRIPTION
Fixes #23 
Makes the graph re-center when window size changes. Switches to using the inbuild d3 window size event listener instead of using the one defined in the main.js. Removes the need for an update_graph_size function defined external to the graph.
Opening an issue because once a node is clicked it stops being responsive. Other parts of the code fix positions of all nodes when a node is clicked so that needs to be dealt with.