### PR TITLE
Stops title from being seen as node

### DIFF
--- a/frontend/src/main/graph.js
+++ b/frontend/src/main/graph.js
@@ -121,7 +121,7 @@ export function create_graph(el, data, config, handle_viz_events) {
             .style("fill", "#555")
             .style("font-family", "Arial")
             .style("font-size", 12)
-            .attr("transform", (d, i, n) => calc_label_pos(d, i, n));
+            .attr("transform", (d, i, n) => calc_label_pos(d, i, n)).style("pointer-events", "none");
 
     /*
      * Event handlers


### PR DESCRIPTION
This removes more of the flickering that was occurring before and makes the page less glitchy. Related to #27 