### PR TITLE
Autocomplete added to the search-bar/Search-bar focuses the graph

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,8 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.25",
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.7",
+    "@material-ui/core": "^4.8.3",
+    "@material-ui/lab": "^4.0.0-alpha.39",
     "@svgr/webpack": "4.1.0",
     "@typescript-eslint/eslint-plugin": "1.6.0",
     "@typescript-eslint/parser": "1.6.0",

--- a/frontend/src/main/graph.js
+++ b/frontend/src/main/graph.js
@@ -332,6 +332,8 @@ function get_gravity_center(d, config, data){
 // eslint-disable-next-line no-unused-vars
 function render_simulation(config, data, data_bindings) {
 
+    console.log('rendergin');
+
     // Update node positions
     data_bindings.nodes.attr("transform", (d) => {
         d.x = Math.max(d.circle_radius, Math.min(config.width - d.circle_radius, d.x));
@@ -544,6 +546,7 @@ export function update_graph(el, data, config, data_bindings, action) {
 
 
     if (action === 'update_focus') {
+
         const link_width_scale_degree_1 = d3.scaleLinear()
             .domain([0, d3.max(data['links'], function(d) { return d.docs})])
             .range([2, 3]);
@@ -574,6 +577,7 @@ export function update_graph(el, data, config, data_bindings, action) {
         svg.selectAll(".graph_node").style("opacity", 1);
         svg.selectAll(".graph_link").style("opacity", 1);
     }
+    render_simulation(config, data, data_bindings);
 }
 
 

--- a/frontend/src/main/graph.js
+++ b/frontend/src/main/graph.js
@@ -429,7 +429,7 @@ function initialize_force_sim(config, data, data_bindings) {
                         .y(force_y_pos)
                         .strength(cluster_strength))
 
-        .force("center", d3.forceCenter().x(config.width / 2).y(config.height / 2))
+        //.force("center", d3.forceCenter().x(config.width / 2).y(config.height / 2))
 
         .force('x_center', d3.forceX()
                         .x(config.width/2)
@@ -541,9 +541,9 @@ export function get_information(data, name){
  * @param action: the update action, e.g. "focus" or "cluster_nodes"
  */
 export function update_graph(el, data, config, data_bindings, action) {
+
+
     if (action === 'update_focus') {
-
-
         const link_width_scale_degree_1 = d3.scaleLinear()
             .domain([0, d3.max(data['links'], function(d) { return d.docs})])
             .range([2, 3]);

--- a/frontend/src/main/graph.js
+++ b/frontend/src/main/graph.js
@@ -21,7 +21,6 @@ import {update_node_degree_and_visibility} from "./node_degree_calculation";
  */
 export function create_graph(el, data, config, handle_viz_events) {
 
-    console.log(data);
 
     // Setup the SVG that we're going to draw the graph into
     const svg = d3.select(el)
@@ -544,7 +543,6 @@ export function get_information(data, name){
 export function update_graph(el, data, config, data_bindings, action) {
     if (action === 'update_focus') {
 
-        console.log("update focus");
 
         const link_width_scale_degree_1 = d3.scaleLinear()
             .domain([0, d3.max(data['links'], function(d) { return d.docs})])

--- a/frontend/src/main/graph.js
+++ b/frontend/src/main/graph.js
@@ -331,9 +331,6 @@ function get_gravity_center(d, config, data){
 // This function is called whenever the simulation updates
 // eslint-disable-next-line no-unused-vars
 function render_simulation(config, data, data_bindings) {
-
-    console.log('rendergin');
-
     // Update node positions
     data_bindings.nodes.attr("transform", (d) => {
         d.x = Math.max(d.circle_radius, Math.min(config.width - d.circle_radius, d.x));

--- a/frontend/src/main/main.css
+++ b/frontend/src/main/main.css
@@ -34,3 +34,9 @@
   margin: 3px 1px;
   cursor: pointer;
 }
+
+.MuiAutocomplete-clearIndicator {
+    visibility: visible !important;
+
+}
+

--- a/frontend/src/main/main.js
+++ b/frontend/src/main/main.js
@@ -4,6 +4,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { Autocomplete } from '@material-ui/lab';
+// eslint-disable-next-line no-unused-vars
+import TextField from '@material-ui/core/TextField';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
@@ -12,7 +16,6 @@ import * as d3 from 'd3';
 import { create_graph, update_graph} from './graph.js'
 import {update_node_degree_and_visibility} from "./node_degree_calculation";
 import './main.css';
-
 
 /***************************************************************************************************
  * Controls
@@ -40,13 +43,25 @@ class Controls extends React.Component {
         return (
             <div className="row">
                 <div className="col-4">
-                    <input className="form-control"
-                        type="text"
-                        maxLength="20" size="20"
+                    <Autocomplete
+                        id="free-solo-demo"
+                        freeSolo
+                        options={this.props.data_names.map(option => option.name)}
+                        renderInput={params => (
+                            // eslint-disable-next-line max-len
+                            <TextField {...params}
+                                placeholder="Type a name here"
+                                maxLength="20" size="20"
+
+                                margin="normal"
+
+                                variant="outlined" fullWidth />
+                        )}
                         value={this.props.searchbar_value}
                         onChange={(e) =>
                             this.validate_searchbar_input_and_maybe_search(e.target.value)}
-                        placeholder={"Type a name here"}
+
+
                     />
                 </div>
                 <div className="col-6">
@@ -99,7 +114,8 @@ Controls.propTypes = {
     handle_searchbar_query: PropTypes.func.isRequired,
     nodes: PropTypes.array.isRequired,
     dataset_name: PropTypes.string.isRequired,
-    update_dataset: PropTypes.func.isRequired
+    update_dataset: PropTypes.func.isRequired,
+    data_names: PropTypes.array
 };
 
 /***************************************************************************************************
@@ -256,12 +272,14 @@ class MainView extends React.Component {
             //show_info_panel: false,
         };
         this.csrftoken = getCookie('csrftoken');
+
     }
     /**
      * Runs when the MainView item is connected to the DOM.
      */
     componentDidMount() {
         this.load_dataset(this.state.config.dataset_name);
+
     }
 
     /**
@@ -419,6 +437,7 @@ class MainView extends React.Component {
                 console.log("error");
                 return false
             });
+
     }
 
 
@@ -440,6 +459,8 @@ class MainView extends React.Component {
     render() {
         if (this.state.data) {
             console.log("fin", this.state.config.searchbar_value);
+            console.log(this.state.data);
+
             return (
                 <div className="container-fluid">
                     <Controls  // this is its own row
@@ -457,6 +478,8 @@ class MainView extends React.Component {
                         update_dataset={
                             (dataset_name) => this.update_dataset(dataset_name)
                         }
+                        data_names={this.state.data.nodes}
+
                     />
 
                     <div className="row">
@@ -483,6 +506,7 @@ class MainView extends React.Component {
                     </div>
                 </div>
             );
+
         } else {
             return (
                 <div>Loading!</div>

--- a/frontend/src/main/main.js
+++ b/frontend/src/main/main.js
@@ -22,19 +22,21 @@ import './main.css';
 class Controls extends React.Component {
     constructor(props) {
         super(props);
+        this.searchbar_ref = React.createRef();
     }
 
     validate_searchbar_input_and_maybe_search(search_string) {
         // Check if the person we're searching for actually exists
+        console.log("Searching: " + search_string);
         const nodes = this.props.nodes;
         for (const node of nodes) {
             const name = node.name;
+
             if (search_string.toLowerCase() === name.toLowerCase()) {
                 this.props.handle_searchbar_query(name, "search");
                 return;
             }
         }
-        this.props.handle_searchbar_query(search_string, "update_searchbar_value")
     }
 
     render() {
@@ -46,19 +48,18 @@ class Controls extends React.Component {
                         freeSolo
                         options={this.props.data_names.map(option => option.name)}
                         renderInput={params => (
-                            // eslint-disable-next-line max-len
                             <TextField {...params}
                                 placeholder="Type a name here"
-                                maxLength="20" size="20"
-
+                                //maxLength="20" size="20"
                                 margin="normal"
+                                variant="outlined" fullWidth
+                                value={this.props.searchbar_value}
+                                onChange={(e) => this.props.update_searchbar_value(e.target.value)}
+                                ref={this.searchbar_ref}
+                            />
 
-
-                                variant="outlined" fullWidth />
                         )}
-                        onChange={(e) =>
-                            this.validate_searchbar_input_and_maybe_search(e.target.value)}
-                        value={this.props.searchbar_value}
+                        onChange={(_event, value) => this.props.update_searchbar_value(value)}
                     />
                 </div>
                 <div className="col-6">
@@ -72,10 +73,15 @@ class Controls extends React.Component {
                             <FontAwesomeIcon icon={faInfoCircle} />
                         </a>
                     </div>
+
                     <button
                         className="button"
-                        onClick={() => this.validate_searchbar_input_and_maybe_search()}
-                    >Search</button>
+                        onClick={() =>
+                            // eslint-disable-next-line max-len
+                            this.validate_searchbar_input_and_maybe_search(this.props.searchbar_value)}
+                    >Search
+                    </button>
+
                     <button
                         className="button"
                         onClick={() => {
@@ -83,6 +89,7 @@ class Controls extends React.Component {
                         }}
                     >Clear</button>
                 </div>
+
                 <div className="col-4">
                     <div className="form-group">
                         <label htmlFor="exampleFormControlSelect1">Dataset</label>
@@ -109,6 +116,7 @@ Controls.propTypes = {
     toggle_checkbox: PropTypes.func,
     toggle_show_table: PropTypes.func,
     handle_searchbar_query: PropTypes.func.isRequired,
+    update_searchbar_value: PropTypes.func.isRequired,
     nodes: PropTypes.array.isRequired,
     dataset_name: PropTypes.string.isRequired,
     update_dataset: PropTypes.func.isRequired,
@@ -365,13 +373,12 @@ class MainView extends React.Component {
      * @param action: String
      */
     handle_searchbar_query(search_string, action) {
+        // eslint-disable-next-line max-len
+        console.log("Handling searchbar query on search: " + search_string + " and action: " + action)
         let config = {... this.state.config};
         config.searchbar_value = search_string;
 
-        // update the searchbar but don't search because the name is not in our dataset
-        if (action === 'update_searchbar_value'){
-            this.setState({config: config})
-        } else if (action === 'search') {
+        if (action === 'search') {
             config.selection_active = true;
             config.selection_name = search_string;
             config.show_info_panel = true;
@@ -391,6 +398,7 @@ class MainView extends React.Component {
         const config = {...this.state.config};
         config.searchbar_value = search_string;
         this.setState({config: config});
+        console.log(this.state.config.searchbar_value)
     }
 
     submitFormHandler = event => {
@@ -459,6 +467,7 @@ class MainView extends React.Component {
                             (search_string, action) => this.handle_searchbar_query(search_string,
                                 action)
                         }
+                        update_searchbar_value={(e) => this.update_searchbar_value(e)}
                         toggle_checkbox={() => this.toggle_checkbox()}f
                         toggle_show_table={() => this.toggle_show_table()}
                         cluster_nodes={this.state.config.cluster_nodes}

--- a/frontend/src/main/main.js
+++ b/frontend/src/main/main.js
@@ -5,9 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Autocomplete } from '@material-ui/lab';
-// eslint-disable-next-line no-unused-vars
-import TextField from '@material-ui/core/TextField';
-
+import { TextField } from '@material-ui/core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
@@ -60,6 +58,7 @@ class Controls extends React.Component {
                         value={this.props.searchbar_value}
                         onChange={(e) =>
                             this.validate_searchbar_input_and_maybe_search(e.target.value)}
+
 
 
                     />
@@ -258,7 +257,7 @@ class MainView extends React.Component {
                 selection_name: undefined,
                 mouseover_active: false,
                 show_info_panel: false,
-                searchbar_value: 'test',
+                searchbar_value: '',
                 selected_viz_degree: 2
             },  // initial configuration for the viz
             data: null,  // data for the viz

--- a/frontend/src/main/main.js
+++ b/frontend/src/main/main.js
@@ -38,13 +38,23 @@ class Controls extends React.Component {
         }
     }
 
+    autocomplete_change(value, reason) {
+        console.log(value + ": In the change function because of: " + reason);
+        if (reason === "clear") {
+            this.props.handle_searchbar_clear();
+        } else {
+            this.validate_searchbar_input_and_maybe_search(value);
+            this.props.update_searchbar_value(value);
+        }
+    }
+
     render() {
         return (
             <div className="row">
                 <div className="col-4">
                     <Autocomplete
                         id="free-solo-demo"
-                        freeSolo
+                        freeSolo={true}
                         options={this.props.data_names.map(option => option.name)}
                         renderInput={params => (
                             <TextField {...params}
@@ -55,9 +65,13 @@ class Controls extends React.Component {
                                 value={this.props.searchbar_value}
                                 onChange={(e) => this.props.update_searchbar_value(e.target.value)}
                             />
-
+                            //TODO Clear X trtigger clear function; search when automcomplete
                         )}
+                        autoComplete={true}
+                        forcePopupIcon={false}
                         onChange={(_event, value) => this.props.update_searchbar_value(value)}
+                        onInputChange={(_event, value, reason) =>
+                            this.autocomplete_change(value, reason)}
                     />
                 </div>
                 <div className="col-6">
@@ -373,7 +387,7 @@ class MainView extends React.Component {
     handle_searchbar_search(search_string) {
         let config = {... this.state.config};
         config.searchbar_value = search_string;
-
+        config.viz_update_func = 'update_focus';
         config.selection_active = true;
         config.selection_name = search_string;
         config.show_info_panel = true;

--- a/frontend/src/main/main.js
+++ b/frontend/src/main/main.js
@@ -289,8 +289,8 @@ class MainView extends React.Component {
     }
 
     focus_graph(person_to_focus) {
-        let data = {... this.state.data};
-        const config = {... this.state.config};
+        let data = this.state.data;
+        const config = this.state.config;
         // update center names to selected node
         console.log(person_to_focus);
         // turning the next two lines into a one-liner gives an error. unclear why.
@@ -395,12 +395,16 @@ class MainView extends React.Component {
      * Content
      */
     handle_searchbar_clear() {
-        let config = {... this.state.config};
+        const config = this.state.config;
+        let data = this.state.data;
+        data.center_names = data.center_names_backup;
         config.searchbar_value = "";
         config.selection_active = false;
         config.selection_name = undefined;
-        const data = update_node_degree_and_visibility(
-            {... this.state.data}, {... this.state.config});
+        config.show_info_panel = false;
+        config.viz_update_func = 'update_focus';
+        data = update_node_degree_and_visibility(
+            data, config);
         this.setState({data: data, config: config});
         console.log("Cleared")
     }

--- a/frontend/src/main/main.js
+++ b/frontend/src/main/main.js
@@ -22,7 +22,6 @@ import './main.css';
 class Controls extends React.Component {
     constructor(props) {
         super(props);
-        this.searchbar_ref = React.createRef();
     }
 
     validate_searchbar_input_and_maybe_search(search_string) {
@@ -33,7 +32,7 @@ class Controls extends React.Component {
             const name = node.name;
 
             if (search_string.toLowerCase() === name.toLowerCase()) {
-                this.props.handle_searchbar_query(name, "search");
+                this.props.handle_searchbar_search(name);
                 return;
             }
         }
@@ -55,7 +54,6 @@ class Controls extends React.Component {
                                 variant="outlined" fullWidth
                                 value={this.props.searchbar_value}
                                 onChange={(e) => this.props.update_searchbar_value(e.target.value)}
-                                ref={this.searchbar_ref}
                             />
 
                         )}
@@ -85,7 +83,7 @@ class Controls extends React.Component {
                     <button
                         className="button"
                         onClick={() => {
-                            this.props.handle_searchbar_query("", "clear");
+                            this.props.handle_searchbar_clear();
                         }}
                     >Clear</button>
                 </div>
@@ -116,6 +114,8 @@ Controls.propTypes = {
     toggle_checkbox: PropTypes.func,
     toggle_show_table: PropTypes.func,
     handle_searchbar_query: PropTypes.func.isRequired,
+    handle_searchbar_search: PropTypes.func.isRequired,
+    handle_searchbar_clear: PropTypes.func.isRequired,
     update_searchbar_value: PropTypes.func.isRequired,
     nodes: PropTypes.array.isRequired,
     dataset_name: PropTypes.string.isRequired,
@@ -367,31 +367,36 @@ class MainView extends React.Component {
     }
 
     /**
-     * Handles search bar update
-     *
-     * @param search_string: String
-     * @param action: String
+     * Searches the graph for the person's name
+     * @param search_string String containing the name to search for
      */
-    handle_searchbar_query(search_string, action) {
-        // eslint-disable-next-line max-len
-        console.log("Handling searchbar query on search: " + search_string + " and action: " + action)
+    handle_searchbar_search(search_string) {
         let config = {... this.state.config};
         config.searchbar_value = search_string;
 
-        if (action === 'search') {
-            config.selection_active = true;
-            config.selection_name = search_string;
-            config.show_info_panel = true;
-            const data = update_node_degree_and_visibility(
-                {... this.state.data}, {... this.state.config}, search_string);
-            this.setState({data: data, config: config});
-        } else if (action === 'clear') {
-            config.selection_active = false;
-            config.selection_name = undefined;
-            const data = update_node_degree_and_visibility(
-                {... this.state.data}, {... this.state.config});
-            this.setState({data: data, config: config});
-        }
+        config.selection_active = true;
+        config.selection_name = search_string;
+        config.show_info_panel = true;
+        const data = update_node_degree_and_visibility(
+            {... this.state.data}, {... this.state.config}, search_string);
+        this.setState({data: data, config: config});
+        console.log("Searched")
+    }
+
+    /**
+     * Clears the searchbar
+     * TODO: Make the clear actually clear the text of the searchbar, propbably will be done in
+     * Content
+     */
+    handle_searchbar_clear() {
+        let config = {... this.state.config};
+        config.searchbar_value = "";
+        config.selection_active = false;
+        config.selection_name = undefined;
+        const data = update_node_degree_and_visibility(
+            {... this.state.data}, {... this.state.config});
+        this.setState({data: data, config: config});
+        console.log("Cleared")
     }
 
     update_searchbar_value(search_string) {
@@ -467,8 +472,11 @@ class MainView extends React.Component {
                             (search_string, action) => this.handle_searchbar_query(search_string,
                                 action)
                         }
+                        handle_searchbar_search={(search_string) =>
+                            this.handle_searchbar_search(search_string)}
+                        handle_searchbar_clear={() => this.handle_searchbar_clear()}
                         update_searchbar_value={(e) => this.update_searchbar_value(e)}
-                        toggle_checkbox={() => this.toggle_checkbox()}f
+                        toggle_checkbox={() => this.toggle_checkbox()}
                         toggle_show_table={() => this.toggle_show_table()}
                         cluster_nodes={this.state.config.cluster_nodes}
                         nodes={this.state.data.nodes}

--- a/frontend/src/main/main.js
+++ b/frontend/src/main/main.js
@@ -53,14 +53,12 @@ class Controls extends React.Component {
 
                                 margin="normal"
 
+
                                 variant="outlined" fullWidth />
                         )}
-                        value={this.props.searchbar_value}
                         onChange={(e) =>
                             this.validate_searchbar_input_and_maybe_search(e.target.value)}
-
-
-
+                        value={this.props.searchbar_value}
                     />
                 </div>
                 <div className="col-6">
@@ -257,7 +255,7 @@ class MainView extends React.Component {
                 selection_name: undefined,
                 mouseover_active: false,
                 show_info_panel: false,
-                searchbar_value: '',
+                searchbar_value: "",
                 selected_viz_degree: 2
             },  // initial configuration for the viz
             data: null,  // data for the viz
@@ -289,7 +287,6 @@ class MainView extends React.Component {
      */
     handle_viz_events(event_name, data) { // eslint-disable-line no-unused-vars
 
-        console.log("viz event", event_name);
 
         if (event_name === 'update_data_bindings'){
             if (!data === null) {
@@ -391,13 +388,9 @@ class MainView extends React.Component {
     }
 
     update_searchbar_value(search_string) {
-        console.log("update bar val", search_string);
         const config = {...this.state.config};
-        console.log(config.searchbar_value);
         config.searchbar_value = search_string;
         this.setState({config: config});
-        console.log(this.state.config.searchbar_value);
-        console.log("update", this.state.config.searchbar_value);
     }
 
     submitFormHandler = event => {
@@ -457,8 +450,6 @@ class MainView extends React.Component {
      */
     render() {
         if (this.state.data) {
-            console.log("fin", this.state.config.searchbar_value);
-            console.log(this.state.data);
 
             return (
                 <div className="container-fluid">

--- a/frontend/src/main/node_degree_calculation.js
+++ b/frontend/src/main/node_degree_calculation.js
@@ -4,13 +4,10 @@ export function update_node_degree_and_visibility(data, config, center_node_name
         data
     }
 
-    console.log("Update degree. Center node:", center_node_name);
-    console.log(data);
 
     data = update_node_degree(data, center_node_name);
     data = update_node_visibility(data, config.selected_viz_degree, center_node_name);
 
-    console.log("data after updated degree", data);
 
     return data
 
@@ -19,7 +16,6 @@ export function update_node_degree_and_visibility(data, config, center_node_name
 
 
 function update_node_degree(data, center_node_name){
-    console.log("updating node degree", center_node_name);
 
     let center_names = {... data.center_names};
     if (center_node_name !== undefined){
@@ -71,7 +67,6 @@ function update_node_degree(data, center_node_name){
 
 function update_node_visibility(data, viz_degree, center_node_name){
 
-    console.log(center_node_name);
 
     data.nodes.forEach((d) => {
 
@@ -89,10 +84,8 @@ function update_node_visibility(data, viz_degree, center_node_name){
         }
 
         if (d.source.name === center_node_name || d.target.name === center_node_name){
-            console.log({...d.source});
             d.source.visibility = 'visible';
             d.target.visibility = 'visible';
-            console.log({...d.source});
         }
     });
 

--- a/frontend/src/main/node_degree_calculation.js
+++ b/frontend/src/main/node_degree_calculation.js
@@ -1,5 +1,5 @@
 export function update_node_degree_and_visibility(data, config, center_node_name) {
-
+    console.log(center_node_name)
     if (center_node_name === undefined){
         data
     }
@@ -18,6 +18,7 @@ export function update_node_degree_and_visibility(data, config, center_node_name
 function update_node_degree(data, center_node_name){
 
     let center_names = {... data.center_names};
+    console.log(center_names)
     if (center_node_name !== undefined){
         center_names[center_node_name] = true
     }

--- a/frontend/src/main/node_degree_calculation.js
+++ b/frontend/src/main/node_degree_calculation.js
@@ -1,5 +1,4 @@
 export function update_node_degree_and_visibility(data, config, center_node_name) {
-    console.log(center_node_name)
     if (center_node_name === undefined){
         data
     }
@@ -18,7 +17,6 @@ export function update_node_degree_and_visibility(data, config, center_node_name
 function update_node_degree(data, center_node_name){
 
     let center_names = {... data.center_names};
-    console.log(center_names)
     if (center_node_name !== undefined){
         center_names[center_node_name] = true
     }


### PR DESCRIPTION
- Autocomplete added to the search-bar allows for easily searching for names in the graph. The API can be found [here](https://material-ui.com/api/autocomplete/)
- The search-bar now focuses when a search is complete, similar to when you click on a node
- Removed the clear and search button and replaced with a exit out button (the x in the search-bar) and a search is triggered when a full name is entered respectively
- The new clear button clears the search-bar as well as unfocuses the graph